### PR TITLE
ui state가 서버에서 공유되지 않도록 함

### DIFF
--- a/apps/usersite/src/app.d.ts
+++ b/apps/usersite/src/app.d.ts
@@ -14,3 +14,18 @@ declare global {
     // interface Platform {}
   }
 }
+
+declare module 'svelte' {
+  type Context = {
+    // see routes/+layout.svelte
+    mobileNavOpen: Writable<boolean>;
+    searchBarOpen: Writable<boolean>;
+    hasCmd: Writable<boolean>;
+  };
+
+  export function getContext<T>(key: T extends keyof Context ? T : never): Context[T];
+
+  export function setContext<T>(key: T extends keyof Context ? T : never, context: Context[T]): void;
+
+  export function getAllContexts(): Map<keyof Context, Context[keyof Context]>;
+}

--- a/apps/usersite/src/lib/stores/ui.ts
+++ b/apps/usersite/src/lib/stores/ui.ts
@@ -1,6 +1,0 @@
-import { writable } from 'svelte/store';
-
-export const mobileNavOpen = writable(false);
-export const treeOpenState = writable<Record<string, boolean>>({});
-export const searchBarOpen = writable(false);
-export const hasCmd = writable(false);

--- a/apps/usersite/src/routes/(default)/+layout.svelte
+++ b/apps/usersite/src/routes/(default)/+layout.svelte
@@ -4,7 +4,7 @@
   import { Icon } from '@readable/ui/components';
   import { getAccessibleTextColor, hexToRgb } from '@readable/ui/utils';
   import qs from 'query-string';
-  import { setContext } from 'svelte';
+  import { getContext, setContext } from 'svelte';
   import { writable } from 'svelte/store';
   import { swipe } from 'svelte-gestures';
   import CommandIcon from '~icons/lucide/command';
@@ -14,7 +14,6 @@
   import { env } from '$env/dynamic/public';
   import { graphql } from '$graphql';
   import { Img } from '$lib/components';
-  import { hasCmd, mobileNavOpen, searchBarOpen } from '$lib/stores/ui';
   import MobileSidebar from './MobileSidebar.svelte';
   import Navigation from './Navigation.svelte';
   import SearchBar from './SearchBar.svelte';
@@ -75,6 +74,10 @@
   const blurEffect = writable(browser ? window.scrollY < blurEffectThreshold : true);
 
   setContext('blurEffect', blurEffect);
+
+  const mobileNavOpen = getContext('mobileNavOpen');
+  const searchBarOpen = getContext('searchBarOpen');
+  const hasCmd = getContext('hasCmd');
 
   function openSearchBar() {
     searchBarOpen.set(true);

--- a/apps/usersite/src/routes/(default)/MobileSidebar.svelte
+++ b/apps/usersite/src/routes/(default)/MobileSidebar.svelte
@@ -3,14 +3,15 @@
   import { flex } from '@readable/styled-system/patterns';
   import { Icon } from '@readable/ui/components';
   import qs from 'query-string';
+  import { getContext } from 'svelte';
   import { fade, fly } from 'svelte/transition';
   import CloseIcon from '~icons/lucide/x';
   import ReadableIcon from '~icons/rdbl/readable';
   import { env } from '$env/dynamic/public';
-  import { mobileNavOpen } from '$lib/stores/ui';
 
   export let siteId: string;
   export let siteUrl: string;
+  const mobileNavOpen = getContext('mobileNavOpen');
 </script>
 
 <svelte:window

--- a/apps/usersite/src/routes/(default)/Navigation.svelte
+++ b/apps/usersite/src/routes/(default)/Navigation.svelte
@@ -2,12 +2,13 @@
   import { css, cx } from '@readable/styled-system/css';
   import { flex } from '@readable/styled-system/patterns';
   import { Icon } from '@readable/ui/components';
+  import { getContext } from 'svelte';
+  import { writable } from 'svelte/store';
   import ChevronDownIcon from '~icons/lucide/chevron-down';
   import ChevronRightIcon from '~icons/lucide/chevron-right';
   import { beforeNavigate } from '$app/navigation';
   import { page } from '$app/stores';
   import { fragment, graphql } from '$graphql';
-  import { mobileNavOpen, treeOpenState } from '$lib/stores/ui';
   import { pageUrl } from '$lib/utils/url';
   import type { Navigation_publicSite } from '$graphql';
 
@@ -82,6 +83,9 @@
   }
 
   let currentPageId: string;
+  const treeOpenState = writable<Record<string, boolean>>({});
+  const mobileNavOpen = getContext('mobileNavOpen');
+
   $: if (currentSlug) {
     // NOTE: 모바일에서 사이드바를 열 때는 현재 페이지만 트리에서 열도록 함
     if ($mobileNavOpen) {

--- a/apps/usersite/src/routes/(default)/SearchBar.svelte
+++ b/apps/usersite/src/routes/(default)/SearchBar.svelte
@@ -3,7 +3,7 @@
   import { center, flex } from '@readable/styled-system/patterns';
   import { HorizontalDivider, Icon } from '@readable/ui/components';
   import * as R from 'remeda';
-  import { tick } from 'svelte';
+  import { getContext, tick } from 'svelte';
   import { writable } from 'svelte/store';
   import SvelteMarkdown from 'svelte-markdown';
   import ChevronLeftIcon from '~icons/lucide/chevron-left';
@@ -14,11 +14,13 @@
   import { beforeNavigate, goto } from '$app/navigation';
   import { page } from '$app/stores';
   import { fragment, graphql } from '$graphql';
-  import { hasCmd, searchBarOpen } from '$lib/stores/ui';
   import { pageUrl } from '$lib/utils/url';
   import AiIcon from './@ai/AiIcon.svelte';
   import AiLoading from './@ai/AiLoading.svelte';
   import type { SearchBar_publicSite } from '$graphql';
+
+  const searchBarOpen = getContext('searchBarOpen');
+  const hasCmd = getContext('hasCmd');
 
   let _publicSite: SearchBar_publicSite;
   export { _publicSite as $publicSite };

--- a/apps/usersite/src/routes/(default)/[...slug]/+page.svelte
+++ b/apps/usersite/src/routes/(default)/[...slug]/+page.svelte
@@ -8,7 +8,6 @@
   import { browser } from '$app/environment';
   import { env } from '$env/dynamic/public';
   import { graphql } from '$graphql';
-  import { mobileNavOpen } from '$lib/stores/ui';
   import Breadcrumb from './Breadcrumb.svelte';
   import Toc from './Toc.svelte';
   import type { Writable } from 'svelte/store';
@@ -45,6 +44,7 @@
   let headings: { level: number; text: string; scrollTop: number }[] = [];
 
   const blurEffect = getContext<Writable<boolean>>('blurEffect');
+  const mobileNavOpen = getContext('mobileNavOpen');
 
   const reportPageView = async (pageId: string) => {
     const { getFingerprint } = await import('$lib/utils/fingerprint');

--- a/apps/usersite/src/routes/+layout.svelte
+++ b/apps/usersite/src/routes/+layout.svelte
@@ -1,12 +1,21 @@
 <script lang="ts">
   import '../app.css';
 
+  import { setContext } from 'svelte';
+  import { writable } from 'svelte/store';
   import { browser } from '$app/environment';
-  import { hasCmd } from '$lib/stores/ui';
 
   export let data: { hasCmd: boolean };
 
+  const mobileNavOpen = writable(false);
+  const searchBarOpen = writable(false);
+  const hasCmd = writable(false);
+
   hasCmd.set(data.hasCmd);
+
+  setContext('mobileNavOpen', mobileNavOpen);
+  setContext('searchBarOpen', searchBarOpen);
+  setContext('hasCmd', hasCmd);
 
   $: if (browser) {
     hasCmd.set(navigator.platform.toUpperCase().includes('MAC') || /(ipad|iphone|ipod)/i.test(navigator.userAgent));


### PR DESCRIPTION
- lib/stores/ui 제거
- treeOpenState는 Navigation에서만 사용되니 그곳으로 옮김
- 대신 context api 사용. root layout에서 setContext
- app.d.ts 에 getContext, setContext 등 타입 override