### PR TITLE
depth 2 이상 li가 margin-top이 0이 되는 css 버그 해결

### DIFF
--- a/packages/ui/styles/prose.css
+++ b/packages/ui/styles/prose.css
@@ -87,7 +87,7 @@
     }
   }
 
-  :is(ul, ol) :is(ul, ol) li:first-child {
+  :is(ul, ol) :is(ul, ol) li:not([role='tab']):first-child {
     margin-top: 4px;
   }
 


### PR DESCRIPTION
specificity가 바뀌어서..