### PR TITLE
병합된 열이 있는 경우에도 ColHandle이 제 위치에 뜨게 함

### DIFF
--- a/packages/ui/src/tiptap/node-views/table/Component.svelte
+++ b/packages/ui/src/tiptap/node-views/table/Component.svelte
@@ -88,6 +88,10 @@
     if (cell) {
       hoveredColumnIndex = (cell as HTMLTableCellElement).cellIndex;
       hoveredRowIndex = (cell.parentElement as HTMLTableRowElement).rowIndex;
+
+      const prevCols = [...(cell.parentElement?.children ?? [])].slice(0, hoveredColumnIndex);
+      // 왼쪽에 병합된 열이 있는 경우를 고려한 hoveredColumnIndex
+      hoveredColumnIndex = prevCols.reduce((acc, col) => acc + (col as HTMLTableCellElement).colSpan, 0);
     }
   }
 </script>


### PR DESCRIPTION
병합된 셀을 고려해서 visual location을 얻어서 처리하면 좋겠지만, 일단 왼쪽에 병합된 열이 있어도 hover한 열에 ColHandle이 뜰 수 있도록 처리하는 것만 해둠