### PR TITLE
위젯에서 인라인 스타일 전체 제거

### DIFF
--- a/sdks/browser-sdk/src/App.svelte
+++ b/sdks/browser-sdk/src/App.svelte
@@ -1,16 +1,15 @@
-<svelte:options customElement={{ tag: 'rdbl-widget' }} />
-
 <script lang="ts">
   import { trpc } from './trpc';
   import Widget from './Widget.svelte';
 
   type Props = {
-    'site-id': string;
+    dom: HTMLElement;
+    siteId: string;
   };
 
-  let { 'site-id': siteId }: Props = $props();
+  let { dom, siteId }: Props = $props();
 </script>
 
 {#await trpc.widget.site.query({ siteId }) then site}
-  <Widget {site} />
+  <Widget {dom} {site} />
 {/await}

--- a/sdks/browser-sdk/src/script.ts
+++ b/sdks/browser-sdk/src/script.ts
@@ -1,8 +1,8 @@
 import '@readable/lib/dayjs';
-import './App.svelte';
 
 import mixpanel from 'mixpanel-browser';
-import styles from './app.css?inline';
+import { mount } from 'svelte';
+import App from './App.svelte';
 
 mixpanel.init(import.meta.env.VITE_MIXPANEL_TOKEN, {
   api_host: 'https://t.rdbl.app',
@@ -25,10 +25,14 @@ mixpanel.register({
 });
 
 const dom = document.createElement('rdbl-widget');
-dom.setAttribute('site-id', siteId);
+const shadow = dom.attachShadow({ mode: 'open' });
 
-const sheet = new CSSStyleSheet();
-sheet.replaceSync(styles);
-dom.shadowRoot?.adoptedStyleSheets.push(sheet);
+mount(App, {
+  target: shadow,
+  props: {
+    dom,
+    siteId,
+  },
+});
 
 document.body.append(dom);

--- a/sdks/browser-sdk/src/vite/css.js
+++ b/sdks/browser-sdk/src/vite/css.js
@@ -1,0 +1,38 @@
+/** @returns {import('vite').Plugin[]} */
+export const css = () => {
+  return [
+    {
+      name: 'css:inline',
+      enforce: 'post',
+
+      resolveId(id) {
+        if (id.endsWith('virtual:style.css?inline')) {
+          return '\u0000css:style.js';
+        }
+      },
+
+      load(id) {
+        if (id === '\u0000css:style.js') {
+          return 'export default __CSS_STYLE_MARKER__';
+        }
+      },
+
+      generateBundle(_, bundle) {
+        let css = '';
+        for (const [name, chunk] of Object.entries(bundle)) {
+          if (name === 'style.css' && chunk.type === 'asset') {
+            css = chunk.source;
+          }
+        }
+
+        for (const [name, chunk] of Object.entries(bundle)) {
+          if (name === 'script.js' && chunk.type === 'chunk') {
+            chunk.code = chunk.code.replaceAll('__CSS_STYLE_MARKER__', JSON.stringify(css));
+          }
+        }
+
+        delete bundle['style.css'];
+      },
+    },
+  ];
+};

--- a/sdks/browser-sdk/svelte.config.js
+++ b/sdks/browser-sdk/svelte.config.js
@@ -3,9 +3,6 @@ import { sveltePreprocess } from 'svelte-preprocess';
 /** @type {import('@sveltejs/kit').Config} */
 export default {
   preprocess: sveltePreprocess(),
-  compilerOptions: {
-    customElement: true,
-  },
   kit: {
     alias: {
       '@/*': '../../apps/api/src/*',

--- a/sdks/browser-sdk/vite.config.ts
+++ b/sdks/browser-sdk/vite.config.ts
@@ -2,6 +2,7 @@ import path from 'node:path';
 import { svelte } from '@sveltejs/vite-plugin-svelte';
 import icons from 'unplugin-icons/vite';
 import { defineConfig } from 'vite';
+import { css } from './src/vite/css';
 
 export default defineConfig({
   plugins: [
@@ -10,6 +11,7 @@ export default defineConfig({
       scale: 1,
       compiler: 'svelte',
     }),
+    css(),
   ],
   resolve: {
     alias: {
@@ -18,6 +20,7 @@ export default defineConfig({
   },
   build: {
     target: 'es2020',
+    cssCodeSplit: false,
     lib: {
       name: 'Readable',
       entry: './src/script.ts',


### PR DESCRIPTION
- custom element 이용 안 하고 shadow dom 직접 조작함
- svelte의 `style:` directive 대신 js의 cssom 이용함
- svelte css module을 constructible style sheet로 변환하는 vite 플러그인 구현함
